### PR TITLE
Fixed network_send_raw to use plaintext strings per https://github.com/VedalAI/neuro-game-sdk/blob/main/API/SPECIFICATION.md, and obj_neurogameapi to parse the data received properly

### DIFF
--- a/ExampleProject/ExampleProject.yyp
+++ b/ExampleProject/ExampleProject.yyp
@@ -21,7 +21,7 @@
   "isEcma":false,
   "LibraryEmitters":[],
   "MetaData":{
-    "IDEVersion":"2024.11.0.179",
+    "IDEVersion":"2024.1100.0.713",
   },
   "name":"ExampleProject",
   "resources":[

--- a/ExampleProject/objects/obj_neurogameapi/Create_0.gml
+++ b/ExampleProject/objects/obj_neurogameapi/Create_0.gml
@@ -40,6 +40,7 @@ global.select_move =
                     "maximum": 2    
                 },
             },
-        "required": [ "move" ]
+        "required": [ "move" ],
+        "type": "object"
     }
 }

--- a/ExampleProject/objects/obj_neurogameapi/Other_68.gml
+++ b/ExampleProject/objects/obj_neurogameapi/Other_68.gml
@@ -21,9 +21,12 @@ if (ds_map_exists(async_load, "id")) {
                         case "select_move":
                             
                             //execute code according to your action
-                            var data = real(struct_get(datastruct,"data"));
+                        
+                            //collect the data variable
+                            var data = struct_get( json_parse( struct_get( datastruct, "data" ) ), "move" );
                             show_debug_message(data);
-                            var moveresult = 0;    
+                            var moveresult = "";
+                                
                             switch data {
                                 case 0:
                                     moveresult = "rock";
@@ -36,7 +39,6 @@ if (ds_map_exists(async_load, "id")) {
                                 case 2:
                                     moveresult = "scissors";
                                  break;
-                                
                             }
                             
                             NeuroSendActionResult(actionid,true,"You have chosen : " + moveresult);

--- a/ExampleProject/scripts/NeuroSendActionResult/NeuroSendActionResult.gml
+++ b/ExampleProject/scripts/NeuroSendActionResult/NeuroSendActionResult.gml
@@ -20,6 +20,6 @@ function NeuroSendActionResult(_action_id = "", _success = false, _result_messag
     
     var buff = buffer_create(string_byte_length(Jason), buffer_fixed, 1);
     buffer_write(buff, buffer_text, Jason);
-    network_send_raw(global.socket, buff, buffer_tell(buff));
+    network_send_raw(global.socket, buff, buffer_tell(buff), network_send_text);
     return _success;
 }

--- a/ExampleProject/scripts/NeuroSendContext/NeuroSendContext.gml
+++ b/ExampleProject/scripts/NeuroSendContext/NeuroSendContext.gml
@@ -18,6 +18,6 @@ function NeuroSendContext( _contextstring = "", _silent = true){
     
     var buff = buffer_create(string_byte_length(Jason), buffer_fixed, 1);
     buffer_write(buff, buffer_text, Jason);
-    network_send_raw(global.socket, buff, buffer_tell(buff));
+    network_send_raw(global.socket, buff, buffer_tell(buff), network_send_text);
     return _contextstring;
 }

--- a/ExampleProject/scripts/NeuroSendForceAction/NeuroSendForceAction.gml
+++ b/ExampleProject/scripts/NeuroSendForceAction/NeuroSendForceAction.gml
@@ -22,6 +22,6 @@ function NeuroSendForceAction( _state = "", _query = "",_eph_context = false, _a
     
     var buff = buffer_create(string_byte_length(Jason), buffer_fixed, 1);
     buffer_write(buff, buffer_text, Jason);
-    network_send_raw(global.socket, buff, buffer_tell(buff));
+    network_send_raw(global.socket, buff, buffer_tell(buff), network_send_text);
     return _action_names;
 }

--- a/ExampleProject/scripts/NeuroSendRegisterAction/NeuroSendRegisterAction.gml
+++ b/ExampleProject/scripts/NeuroSendRegisterAction/NeuroSendRegisterAction.gml
@@ -21,6 +21,6 @@ function NeuroSendRegisterAction( _actionarray = []){
     
     var buff = buffer_create(string_byte_length(Jason), buffer_fixed, 1);
     buffer_write(buff, buffer_text, Jason);
-    network_send_raw(global.socket, buff, buffer_tell(buff));
+    network_send_raw(global.socket, buff, buffer_tell(buff), network_send_text);
     return _actionarray;
 }

--- a/ExampleProject/scripts/NeuroSendStartup/NeuroSendStartup.gml
+++ b/ExampleProject/scripts/NeuroSendStartup/NeuroSendStartup.gml
@@ -12,5 +12,5 @@ function NeuroSendStartup(){
     
     var buff = buffer_create(string_byte_length(Jason), buffer_fixed, 1);
     buffer_write(buff, buffer_text, Jason);
-    network_send_raw(global.socket, buff, buffer_tell(buff));
+    network_send_raw(global.socket, buff, buffer_tell(buff), network_send_text);
 }

--- a/ExampleProject/scripts/NeuroSendUnregisterAction/NeuroSendUnregisterAction.gml
+++ b/ExampleProject/scripts/NeuroSendUnregisterAction/NeuroSendUnregisterAction.gml
@@ -25,6 +25,6 @@ function NeuroSendUnregisterAction(_actionnames = []){
     
     var buff = buffer_create(string_byte_length(Jason), buffer_fixed, 1);
     buffer_write(buff, buffer_text, Jason);
-    network_send_raw(global.socket, buff, buffer_tell(buff));
+    network_send_raw(global.socket, buff, buffer_tell(buff), network_send_text);
     return _actionnames;
 }

--- a/ExampleProject/scripts/NeuroSendUnregisterAll/NeuroSendUnregisterAll.gml
+++ b/ExampleProject/scripts/NeuroSendUnregisterAll/NeuroSendUnregisterAll.gml
@@ -18,5 +18,5 @@ function NeuroSendUnregisterAll(){
     
     var buff = buffer_create(string_byte_length(Jason), buffer_fixed, 1);
     buffer_write(buff, buffer_text, Jason);
-    network_send_raw(global.socket, buff, buffer_tell(buff));
+    network_send_raw(global.socket, buff, buffer_tell(buff), network_send_text);
 }


### PR DESCRIPTION
Commit message: Fixed network_send_raw to use plaintext strings per https://github.com/VedalAI/neuro-game-sdk/blob/main/API/SPECIFICATION.md, and obj_neurogameapi to parse the data received properly

I was testing this with [gpt4o through neuro-api-jippity](https://github.com/EnterpriseScratchDev/neuro-api-jippity) since it's the closest to what Neuro-sama would actually send to games.

The server was expecting plaintext, so I changed all network_send_raw packets to specify network_send_text as the data type.

A schema "type" wasn't selected, and it expected "type":"object" so I added that to the example schema's root.

The "move" variable sent back from gpt4o was a JSON string not a number, so I changed it to parse the "move" variable as a JSON string.